### PR TITLE
1245 - moved swagger ui

### DIFF
--- a/playbooks/group_vars/frontend
+++ b/playbooks/group_vars/frontend
@@ -192,7 +192,7 @@ nginx_sites:
         uwsgi_pass 127.0.0.1:8081;
       }
     - location /swagger {
-        alias {{ frontend_install_dir }}/docs/api/swagger-ui/;
+        alias {{ frontend_install_dir }}/web/swagger-ui/;
         index index.html;
       }
     - location / {


### PR DESCRIPTION
The following PR is related to https://github.com/quarkslab/irma-frontend/pull/40. The related PR moved away:

1. the swagger web ui from docs (which btw was already deleted) to web and
2. The swagger specs from docs to the doc module.