### PR TITLE
brain_addr: s/127.0.0.1/brain.irma/

### DIFF
--- a/playbooks/group_vars/all
+++ b/playbooks/group_vars/all
@@ -30,7 +30,7 @@ irma_server_group: irma-server
 irma_cert_group: irma-cert
 
 irma_configurations:
-  brain_addr: 127.0.0.1
+  brain_addr: brain.irma
   rabbitmq:
     brain:
       vhost: mqbrain


### PR DESCRIPTION
Changing brain_addr default value for brain.irma, mainly to fix problems when creating a new environment based on prod environment for instance.