### PR TITLE
Change ftp URL to http for virusblokada tgz fetching

### DIFF
--- a/roles/quarkslab.virusblokada/defaults/main.yml
+++ b/roles/quarkslab.virusblokada/defaults/main.yml
@@ -1,4 +1,4 @@
 ---
 
-virusblokada_tgz_url: "ftp://anti-virus.by/pub/vbacl-linux-3.12.10.6-20090601.tar.gz"
+virusblokada_tgz_url: "http://anti-virus.by/pub/vbacl-linux-3.12.10.6-20090601.tar.gz"
 virusblokada_temp_dir: "/tmp/vba32"


### PR DESCRIPTION
While installing irma through ansible in a specific server with specifics iptables rules, I wasn't able to fetch this file through port 21.
Please note that this file is accessible through HTTP as well. There is very few scenarios where ftp is allowed but not http. Therefore, I think it would be smart to replace this URL by its HTTP version.