### PR TITLE
Fix error when deploying IRMA using Vagrant > 1.7.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -37,7 +37,7 @@ Everything will be installed in the same virtual machine named `brain.irma`.
 Requirements
 ````````````
 
-- `Vagrant <http://www.vagrantup.com/>`_ 1.5 or higher has to be installed
+- `Vagrant <http://www.vagrantup.com/>`_ 1.8 or higher has to be installed
 - As the installation work only for `Virtualbox <https://www.virtualbox.org/>`_,
   you’ll need to install it
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -82,7 +82,8 @@ Vagrant.configure("2") do |config|
       ansible.playbook = 'playbooks/playbook.yml'
       ansible.extra_vars = ansible_config['extra_vars']
       ansible.groups = ansible_config['groups']
-      
+      ansible.force_remote_user = false
+
       # NOTE: ansible.limit = 'all' is incompatible when provisioning windows
       #ansible.limit = 'all'
       #ansible.tags = ['']


### PR DESCRIPTION
With the new Vagrant "ansible.force_remote_user" option set to true by
default, SSH User used to connect to the VM is now set to "vagrant" into
the Ansible inventory (generated by Vagrant).
This behavior does not permit to use Ansible "remote_user" option into
playbooks (overridden by the inventory), that's the reason why the
deployment fail.