### PR TITLE
Change ansible role from quarkslab to defaul user.

### DIFF
--- a/ansible-requirements.yml
+++ b/ansible-requirements.yml
@@ -3,9 +3,8 @@
 - src: ANXS.openssh
   version: v1.0.1
 
-- src: https://github.com/quarkslab/postgresql.git
-  name: ANXS.postgresql
-  version: master
+- src: ANXS.postgresql
+  version: v1.1.1
 
 - src: franklinkim.sudo
   version: 1.0.0
@@ -26,6 +25,5 @@
 - src: mivok0.users
   version: master
 
-- src: https://github.com/quarkslab/Stouts.mongodb.git
-  name: Stouts.mongodb
-  version: develop
+- src: Stouts.mongodb
+  version: 2.1.11

--- a/playbooks/group_vars/frontend-demo.yml
+++ b/playbooks/group_vars/frontend-demo.yml
@@ -117,21 +117,13 @@ nodejs_global_packages:
 
 
 ## MongoDB
-mongodb_from_mongodb_repo: "{{ not (default_use_debian_repo | bool) }}"
+mongodb_package: "{{'mongodb' if default_use_debian_repo|default(False) else 'mongodb-org'}}"
 
 
 ## PostgreSQL role
 # Basic settings
-postgresql_from_pg_repo: "{{ not (default_use_debian_repo | bool) }}"
-
-postgresql_version: "{{ '9.3' if not default_use_debian_repo|default(False) else '9.1' }}"
-postgresql_shared_buffers: "{{ '128MB' if not default_use_debian_repo|default(False) else '24MB' }}"
-
-postgresql_admin_user: "postgres"
-postgresql_default_auth_method: "trust"
-
-postgresql_cluster_name: "main"
-postgresql_cluster_reset: false
+postgresql_version: "9.3"
+postgresql_client_encoding: "UTF8"
 
 ## Databases informations
 postgresql_databases:

--- a/playbooks/group_vars/frontend.yml
+++ b/playbooks/group_vars/frontend.yml
@@ -113,22 +113,12 @@ nodejs_global_packages:
 
 
 ## MongoDB
-mongodb_from_mongodb_repo: "{{ not (default_use_debian_repo | bool) }}"
+mongodb_package: "{{'mongodb' if default_use_debian_repo|default(False) else 'mongodb-org'}}"
 
 
 ## PostgreSQL role
 # Basic settings
-postgresql_from_pg_repo: "{{ not (default_use_debian_repo | bool) }}"
-
-postgresql_version: "{{ '9.3' if not default_use_debian_repo|default(False) else '9.1' }}"
-postgresql_shared_buffers: "{{ '128MB' if not default_use_debian_repo|default(False) else '24MB' }}"
-
-postgresql_admin_user: "postgres"
-postgresql_default_auth_method: "trust"
-
-postgresql_cluster_name: "main"
-postgresql_cluster_reset: false
-
+postgresql_version: "9.3"
 postgresql_client_encoding: "UTF8"
 
 ## Databases informations


### PR DESCRIPTION
Our role are not properly update to the last modification. We decided to
switch to more Ansible community-driven roles.
Be careful, the update of PostgreSQL introduce a regression with the
"APT Repos-only" installation.