### PR TITLE
Change Ansible role for configuring OpenSSH.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,8 +9,8 @@ roles/Mayeu.RabbitMQ/
 roles/mivok0.users/
 roles/Stouts.mongodb/
 roles/ANXS.postgresql/
-roles/ANXS.openssh/
 roles/gdamjan.uwsgi/
+roles/willshersystems.sshd
 
 files/*
 !files/.gitkeep

--- a/ansible-requirements.yml
+++ b/ansible-requirements.yml
@@ -1,9 +1,5 @@
 ---
 
-- src: https://github.com/ANXS/openssh.git
-  version: v1.1.0
-  name: ANXS.openssh
-
 - src: https://github.com/ANXS/postgresql.git
   version: v1.3.0
   name: ANXS.postgresql
@@ -34,3 +30,7 @@
 
 - src: Stouts.mongodb
   version: 2.1.11
+
+- src: https://github.com/willshersystems/ansible-sshd.git
+  version: 0.4.2
+  name: willshersystems.sshd

--- a/playbooks/group_vars/all.yml
+++ b/playbooks/group_vars/all.yml
@@ -69,6 +69,11 @@ ufw_applications:
   - { name: "OpenSSH" }
 
 ## OpenSSH server config
-openssh_server_settings:
-  # Stop accepting locale on the server
+sshd:
   AcceptEnv: LANG
+  IgnoreRhost: yes
+  LogLevel: INFO
+  PermitEmptyPasswords: no
+  PermitRootLogin: no
+  Protocol: 2
+  X11Forwarding: no

--- a/playbooks/provisioning.yml
+++ b/playbooks/provisioning.yml
@@ -9,7 +9,7 @@
     - { role: quarkslab.irma_provisioning_common, tags: 'common' }
     - { role: mivok0.users, tags: 'users' }
     - { role: franklinkim.sudo, tags: 'sudo' }
-    - { role: ANXS.openssh, tags: 'openssh' }
+    - { role: willshersystems.sshd, tags: 'openssh' }
 
 
 - name: Frontend provisioning


### PR DESCRIPTION
The old Ansible role, made by ANXS, was not configurable without the
hash.merge behavior.
We may need this option to be removed from the ansible.cfg config
file in the future.