### PR TITLE
Adapt Ansible provisioning to the new repository organisation including

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -37,7 +37,9 @@ Everything will be installed in the same virtual machine named `brain.irma`.
 Requirements
 ````````````
 
-- `Vagrant <http://www.vagrantup.com/>`_ 1.8 or higher has to be installed
+- `Vagrant <http://www.vagrantup.com/>`_ 1.8 or higher has to be installed. You
+  should have the following plugins too:
+    - `vagrant-hostmanager <https://github.com/smdahlen/vagrant-hostmanager>`
 - As the installation work only for `Virtualbox <https://www.virtualbox.org/>`_,
   you’ll need to install it
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -35,6 +35,13 @@ Vagrant.configure("2") do |config|
     end
   end
 
+  # Plugin vagrant-hostmanager
+  config.hostmanager.enabled = true
+  config.hostmanager.manage_host = true
+  config.hostmanager.manage_guest = true
+  config.hostmanager.ignore_private_ip = false
+  config.hostmanager.include_offline = true
+
   # Multi machine environment
   servers.each do |server|
     config.vm.define server['name'] do |machine|
@@ -47,6 +54,8 @@ Vagrant.configure("2") do |config|
         print server['ip'], "\n"
         machine.vm.network "private_network", ip: server['ip']
       end
+
+      machine.hostmanager.aliases = server['aliases'] || []
 
       if server.has_key?('shares')
         server['shares'].each do |share|

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,5 +1,4 @@
 [defaults]
-hash_behaviour     = merge
 ansible_managed    = Please do not change this file directly since it is managed by Ansible and will be overwritten
 # ansible_managed = Ansible managed: {file} modified on %Y-%m-%d %H:%M:%S by {uid} on {host}
 roles_path         = ./roles

--- a/environments/allinone_dev.yml
+++ b/environments/allinone_dev.yml
@@ -2,22 +2,22 @@
 # Variables used by Vagrantfile are defined here
 
 servers:
-  - name: brain.irma
+  - name: brain
     box: quarkslab/debian-8.2.0-amd64
     ip: 172.16.1.30
     hostname: brain.irma
     cpus: 2
     cpuexecutioncap: 100
     memory: 2048
+    aliases:
+        - www.irma.dev
+        - api.irma.dev
     shares:
       - share_from: ../irma-frontend
         share_to: /opt/irma/irma-frontend/current
         share_exclude:
           - .git/
           - venv/
-          - web/dist
-          - web/node_modules
-          - app/components
       - share_from: ../irma-brain
         share_to: /opt/irma/irma-brain/current
         share_exclude:
@@ -29,6 +29,13 @@ servers:
         share_exclude:
           - .git/
           - venv/
+      - share_from: ../irma-web-ui
+        share_to: /opt/irma/irma-web-ui/current
+        share_exclude:
+          - .git/
+          - dist
+          - node_modules
+          - app/components
 ## NOTE: The following adds a windows VM to IRMA. This is not enabled by
 ## default in allinone_dev because of known limitations due to shared folders.
 ## Please have a look at the documentation if ## you want to enable this in an dev
@@ -58,6 +65,8 @@ ansible_config:
     frontend:
       - brain.irma
     brain:
+      - brain.irma
+    web-ui:
       - brain.irma
     clamav:
       - brain.irma

--- a/environments/allinone_prod.yml
+++ b/environments/allinone_prod.yml
@@ -2,13 +2,16 @@
 # Variables used by Vagrantfile are defined here
 
 servers:
-  - name: brain.irma
+  - name: irma_allinone_prod
     box: quarkslab/debian-8.2.0-amd64
     ip: 172.16.1.30
     hostname: brain.irma
     cpus: 2
     cpuexecutioncap: 100
     memory: 2048
+    aliases:
+        - www.irma.dev
+        - api.irma.dev
     share_code: false
 ##   - name: probe-win.irma
 ##     box: eval-win8x64-enterprise
@@ -24,21 +27,23 @@ ansible_config:
     vagrant: true
   groups:
     frontend:
-      - brain.irma
+      - irma_allinone_prod
     brain:
-      - brain.irma
+      - irma_allinone_prod
+    web-ui:
+      - irma_allinone_prod
     clamav:
-      - brain.irma
+      - irma_allinone_prod
     comodo:
-      - brain.irma
+      - irma_allinone_prod
     mcafee:
-      - brain.irma
+      - irma_allinone_prod
     trid:
-      - brain.irma
+      - irma_allinone_prod
     static-analyzer:
-      - brain.irma
+      - irma_allinone_prod
     virustotal:
-      - brain.irma
+      - irma_allinone_prod
 ##    windows-probe:
 ##      - probe-win.irma
     "probe:children":

--- a/playbooks/deployment.yml
+++ b/playbooks/deployment.yml
@@ -6,6 +6,12 @@
   roles:
     - { role: quarkslab.irma_deployment_frontend, tags: 'deployment_frontend' }
 
+- name: Web User-Interface deployment
+  hosts: "web-ui"
+  remote_user: "{{web_ui_user}}"
+  roles:
+    - { role: quarkslab.irma_deployment_web_ui, tags: 'deployment_web_ui' }
+
 - name: Brain deployment
   hosts: brain
   remote_user: "{{ brain_user }}"

--- a/playbooks/group_vars/all.yml
+++ b/playbooks/group_vars/all.yml
@@ -68,6 +68,20 @@ ufw_login: on
 ufw_applications:
   - { name: "OpenSSH" }
 
+
+## Nginx
+nginx_configs:
+  http:
+    - server_names_hash_bucket_size 64
+  zip:
+    - gzip on
+    - gzip_disable "msie6"
+    - gzip_comp_level 6
+    - gzip_buffers 16 8k
+    - gzip_http_version 1.1
+    - gzip_types text/plain text/css application/json application/x-javascript text/javascript application/javascript
+
+
 ## OpenSSH server config
 sshd:
   AcceptEnv: LANG

--- a/playbooks/group_vars/frontend-demo.yml
+++ b/playbooks/group_vars/frontend-demo.yml
@@ -191,7 +191,7 @@ nginx_configs:
     - server_names_hash_bucket_size 64
 
 nginx_sites:
-  default:
+  irma-frontend:
     - listen 80 default_server
     - listen [::]:80 default_server ipv6only=on
     - server_name _

--- a/playbooks/group_vars/frontend.yml
+++ b/playbooks/group_vars/frontend.yml
@@ -1,7 +1,7 @@
 ---
 
 ## Global variables
-hostname: frontend.irma
+frontend_hostname: "frontend.irma.dev"
 
 frontend_user: "{{ default_user }}"
 frontend_group: "{{ default_group }}"
@@ -164,8 +164,17 @@ supervisor_programs_frontend:
     killasgroup: true
 
 
-## Nginx role
-nginx_configs:
+## Nginx
+nginx_configs_frontend:
+  http:
+    - server_names_hash_bucket_size 64
+  zip:
+    - gzip on
+    - gzip_disable "msie6"
+    - gzip_comp_level 6
+    - gzip_buffers 16 8k
+    - gzip_http_version 1.1
+    - gzip_types text/plain text/css application/json application/x-javascript text/javascript application/javascript
   proxy:
     - proxy_set_header X-Real-IP $remote_addr
     - proxy_set_header Host $http_host
@@ -175,23 +184,12 @@ nginx_configs:
     - proxy_http_version 1.1
     - proxy_set_header Upgrade $http_upgrade
     - proxy_set_header Connection "upgrade"
-  gzip:
-    - gzip on
-    - gzip_disable "msie6"
-    - gzip_comp_level 6
-    - gzip_buffers 16 8k
-    - gzip_http_version 1.1
-    - gzip_types text/plain text/css application/json application/x-javascript text/javascript application/javascript
-  http:
-    - server_names_hash_bucket_size 64
 
-nginx_sites:
-  default:
-    - listen 80
+
+nginx_sites_frontend:
   irma-frontend:
-    - listen 80 default_server
-    - listen [::]:80 default_server ipv6only=on
-    - server_name www.{{ hostname }}
+    - listen 80
+    - server_name {{ frontend_hostname }}
     - client_max_body_size 100m
     - location ~ /\.ht {
         deny all;
@@ -205,21 +203,14 @@ nginx_sites:
         alias {{ frontend_install_dir }}/swagger/ui;
         index index.html;
       }
-    - location / {
-        expires -1;
-        add_header Pragma "no-cache";
-        add_header Cache-Control "no-store, no-cache, must-revalidate, post-check=0, pre-check=0";
-        root {{ frontend_install_dir }}/web/dist;
-        try_files $uri $uri/ /index.html =404;
-      }
-    - error_log {{ nginx_log_dir }}/{{ hostname }}.error.log
-    - access_log {{ nginx_log_dir }}/{{ hostname }}.access.log
+    - error_log {{ nginx_log_dir }}/{{ frontend_hostname }}.error.log
+    - access_log {{ nginx_log_dir }}/{{ frontend_hostname }}.access.log
   # Uncomment the following for HTTPs using OpenSSL support
   # It can be customize for your needs (add the swagger API, …)
   #irma-frontend-https:
     #- listen 443 default_server
     #- listen [::]:443 default_server ipv6only=on
-    #- server_name www.{{ hostname }}
+    #- server_name {{ frontend_hostname }}
     #- client_max_body_size 100m
     #- location ~ /\.ht {
         #deny all;
@@ -229,12 +220,8 @@ nginx_sites:
         #rewrite ^/_api/(.+) /$1 break;
         #uwsgi_pass 127.0.0.1:8081;
       #}
-    #- location / {
-        #alias {{ frontend_install_dir }}/web/dist/;
-        #index index.html;
-      #}
-    #- error_log {{ nginx_log_dir }}/{{ hostname }}.error.log
-    #- access_log {{ nginx_log_dir }}/{{ hostname }}.access.log
+    #- error_log {{ nginx_log_dir }}/{{ frontend_hostname }}.error.log
+    #- access_log {{ nginx_log_dir }}/{{ frontend_hostname }}.access.log
     ## TLS configuration
     #- ssl on
     #- ssl_certificate {{ frontend_openssl_certificates.cert.dst }}

--- a/playbooks/group_vars/web-ui.yml
+++ b/playbooks/group_vars/web-ui.yml
@@ -1,0 +1,99 @@
+---
+
+## Global variables
+web_ui_hostname: "irma.dev"
+
+web_ui_user: "{{ default_user }}"
+web_ui_group: "{{ default_group }}"
+web_ui_project_dir: "/opt/irma/web-ui"
+
+web_ui_install_dir: "{{ web_ui_project_dir }}/current"
+web_ui_releases_dir: "{{ web_ui_project_dir }}/releases"
+
+
+## Deployment
+web_ui_deployment_repository: "https://github.com/quarkslab/irma-web-ui.git"
+
+
+## UFW Rules
+web_ui_ufw_additional_rules:
+  - port: 80
+    rule: allow
+  - port: 443
+    rule: "{{ 'allow' if web_ui_openssl|default('False') else 'deny' }}"
+
+
+## HTTPs
+web_ui_openssl: False # Default value is False. For HTTPs using OpenSSL,
+                        # change it to True
+web_ui_openssl_dh_param: /etc/nginx/certs/{{ hostname }}_dhparam.pem
+
+web_ui_openssl_certificates:
+  cert:
+    src: files/{{ hostname }}/hostname.crt
+    dst: /etc/nginx/certs/{{ hostname }}.crt
+  key:
+    src: files/{{ hostname }}/hostname.key
+    dst: /etc/nginx/certs/{{ hostname }}.key
+  ca:
+    src: files/{{ hostname }}/ca.crt
+    dst: /etc/nginx/certs/ca.crt
+
+
+## Apt role
+apt_repositories_code_names:
+  - '{{ ansible_distribution_release }}'
+  - '{{ ansible_distribution_release }}-updates'
+
+
+## Nginx role
+nginx_sites_web_ui:
+  irma-web-ui:
+    - listen 80 default_server
+    - listen [::]:80 default_server ipv6only=on
+    - server_name {{ web_ui_hostname }} www.{{ web_ui_hostname }}
+    - client_max_body_size 100m
+    - location ~ /\.ht {
+        deny all;
+      }
+    - location / {
+        expires -1;
+        add_header Pragma "no-cache";
+        add_header Cache-Control "no-store, no-cache, must-revalidate, post-check=0, pre-check=0";
+        root {{ web_ui_install_dir }}/web/dist;
+        try_files $uri $uri/ /index.html =404;
+      }
+    - error_log {{ nginx_log_dir }}/{{ web_ui_hostname }}.error.log
+    - access_log {{ nginx_log_dir }}/{{ web_ui_hostname }}.access.log
+  # Uncomment the following for HTTPs using OpenSSL support
+  # It can be customize for your needs
+  #irma-web-ui-https:
+    #- listen 443 default_server
+    #- listen [::]:443 default_server ipv6only=on
+    #- server_name {{ web_ui_hostname }} www.{{ web_ui_hostname }}
+    #- client_max_body_size 100m
+    #- location ~ /\.ht {
+        #deny all;
+      #}
+    #- location / {
+        #alias {{ web_ui_install_dir }}/web/dist/;
+        #index index.html;
+      #}
+    #- error_log {{ nginx_log_dir }}/{{ web_ui_hostname }}.error.log
+    #- access_log {{ nginx_log_dir }}/{{ web_ui_hostname }}.access.log
+    ## TLS configuration
+    #- ssl on
+    #- ssl_certificate {{ web_ui_openssl_certificates.cert.dst }}
+    #- ssl_certificate_key {{ web_ui_openssl_certificates.key.dst }}
+    ## dhparam of 2048 bit or greater (1024 if java6 required)
+    #- ssl_dhparam {{ web_ui_openssl_dh_param }}
+    #- ssl_session_timeout 5m
+    #- ssl_protocols SSLv3 TLSv1 TLSv1.1 TLSv1.2
+    #- ssl_ciphers 'ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA:ECDHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA256:DHE-RSA-AES128-SHA256:DHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA:ECDHE-RSA-DES-CBC3-SHA:EDH-RSA-DES-CBC3-SHA:AES256-GCM-SHA384:AES128-GCM-SHA256:AES256-SHA256:AES128-SHA256:AES256-SHA:AES128-SHA:DES-CBC3-SHA:HIGH:!aNULL:!eNULL:!EXPORT:!CAMELLIA:!DES:!MD5:!PSK:!RC4'
+    #- ssl_prefer_server_ciphers on
+    ## TLS session cache
+    #- ssl_session_cache shared:SSL:50m
+    ## HSTS record cache for 6 months
+    #- add_header Strict-Transport-Security max-age=15768000
+
+# vim: sw=2

--- a/playbooks/provisioning.yml
+++ b/playbooks/provisioning.yml
@@ -22,8 +22,17 @@
     - { role: ANXS.postgresql, tags: 'postgresql' }
     - { role: quarkslab.supervisor, tags: 'supervisor', supervisor_programs: "{{ supervisor_programs_frontend }}" }
     - { role: quarkslab.irma_provisioning_frontend, tags: 'frontend' }
-    - { role: jdauphant.nginx, tags: 'nginx' }
+    - { role: jdauphant.nginx, tags: 'nginx', nginx_sites: "{{nginx_sites_frontend}}", nginx_configs: "{{nginx_configs_frontend}}" }
     - { role: quarkslab.ufw_additional, tags: 'ufw', ufw_additional_rules: "{{ frontend_ufw_additional_rules }}" }
+
+
+- name: Web-ui provisioning
+  hosts: web-ui
+  sudo: yes
+  roles:
+    - { role: quarkslab.irma_provisioning_web_ui, tags: 'web_ui' }
+    - { role: jdauphant.nginx, tags: 'nginx', nginx_sites: "{{nginx_sites_web_ui}}" }
+    - { role: quarkslab.ufw_additional, tags: 'ufw', ufw_additional_rules: "{{ web_ui_ufw_additional_rules }}" }
 
 
 - name: Brain provisioning

--- a/roles/quarkslab.irma_deployment_frontend/tasks/main.yml
+++ b/roles/quarkslab.irma_deployment_frontend/tasks/main.yml
@@ -23,38 +23,38 @@
     virtualenv_site_packages: yes
     extra_args: "{{ pip_extra_args | default('') }}"
 
-- name: Copy previous Npm files
-  shell: "cp -R {{frontend_install_dir}}/web/node_modules {{frontend_deployment_dir}}/web/node_modules"
-  args:
-    remotes: "{{frontend_install_dir}}/web/node_modules"
-    creates: "{{frontend_deployment_dir}}/web/node_modules"
-  # Errors when current does not exists (first deployment)
-  ignore_errors: yes
+#- name: Copy previous Npm files
+  #shell: "cp -R {{frontend_install_dir}}/web/node_modules {{frontend_deployment_dir}}/web/node_modules"
+  #args:
+    #remotes: "{{frontend_install_dir}}/web/node_modules"
+    #creates: "{{frontend_deployment_dir}}/web/node_modules"
+  ## Errors when current does not exists (first deployment)
+  #ignore_errors: yes
 
-- name: Install NPM dependencies
-  npm:
-    path: "{{ frontend_deployment_dir }}/web"
-    production: "{{ irma_environment == 'production' }}"
-    ignore_scripts: yes
-    state: latest
+#- name: Install NPM dependencies
+  #npm:
+    #path: "{{ frontend_deployment_dir }}/web"
+    #production: "{{ irma_environment == 'production' }}"
+    #ignore_scripts: yes
+    #state: latest
 
-- name: Copy previous Bower files
-  shell: "cp -R {{frontend_install_dir}}/web/app/components {{frontend_deployment_dir}}/web/app/components"
-  args:
-    remotes: "{{frontend_install_dir}}/web/app/components"
-    creates: "{{frontend_deployment_dir}}/web/app/components"
-  # Errors when current does not exists (first deployment)
-  ignore_errors: yes
+#- name: Copy previous Bower files
+  #shell: "cp -R {{frontend_install_dir}}/web/app/components {{frontend_deployment_dir}}/web/app/components"
+  #args:
+    #remotes: "{{frontend_install_dir}}/web/app/components"
+    #creates: "{{frontend_deployment_dir}}/web/app/components"
+  ## Errors when current does not exists (first deployment)
+  #ignore_errors: yes
 
-- name: Install Bower dependencies
-  command: node_modules/.bin/bower install --config.interactive=false
-  args:
-    chdir: "{{ frontend_deployment_dir }}/web"
+#- name: Install Bower dependencies
+  #command: node_modules/.bin/bower install --config.interactive=false
+  #args:
+    #chdir: "{{ frontend_deployment_dir }}/web"
 
-- name: Generate Web Frontend
-  command: node_modules/.bin/gulp dist
-  args:
-    chdir: "{{ frontend_deployment_dir }}/web"
+#- name: Generate Web Frontend
+  #command: node_modules/.bin/gulp dist
+  #args:
+    #chdir: "{{ frontend_deployment_dir }}/web"
 
 - name: Configure config/frontend.ini file
   ini_file:
@@ -89,3 +89,5 @@
   sudo: yes
   with_items:
     - nginx
+
+# vim: sw=2

--- a/roles/quarkslab.irma_deployment_web_ui/defaults/main.yml
+++ b/roles/quarkslab.irma_deployment_web_ui/defaults/main.yml
@@ -1,0 +1,7 @@
+---
+
+web_ui_project_dir: "/opt/irma/web-ui"
+web_ui_deployment_repository: "https://github.com/quarkslab/irma-web-ui.git"
+web_ui_install_dir: "{{ web_ui_project_dir }}/current"
+
+# vim: sw=2

--- a/roles/quarkslab.irma_deployment_web_ui/tasks/main.yml
+++ b/roles/quarkslab.irma_deployment_web_ui/tasks/main.yml
@@ -1,0 +1,61 @@
+---
+
+# TODO: Add if statement for generating, or retrieve interface already generated
+
+- set_fact:
+    web_ui_deployment_dir: "{{ web_ui_project_dir }}/{{ 'current' if irma_deployment_code_version == 'local' else 'releases/' + irma_deployment_release_name }}"
+
+- name: Ensure that releases directory has been created
+  file:
+    path: "{{ web_ui_project_dir }}/releases"
+    state: directory
+
+- name: Clone repository
+  git:
+    repo: "{{ web_ui_deployment_repository }}"
+    dest: "{{ web_ui_deployment_dir }}"
+    version: "{{ irma_deployment_code_version }}"
+    accept_hostkey: yes
+  when: irma_deployment_code_version != 'local'
+
+- name: Copy previous Npm files
+  shell: "cp -R {{web_ui_install_dir}}/node_modules {{web_ui_deployment_dir}}/node_modules"
+  args:
+    remotes: "{{web_ui_install_dir}}/node_modules"
+    creates: "{{web_ui_deployment_dir}}/node_modules"
+  # Errors when current does not exists (first deployment)
+  ignore_errors: yes
+
+- name: Install NPM dependencies
+  npm:
+    path: "{{ web_ui_deployment_dir }}"
+    production: "{{ irma_environment == 'production' }}"
+    ignore_scripts: yes
+    state: latest
+
+- name: Copy previous Bower files
+  shell: "cp -R {{web_ui_install_dir}}/app/components {{web_ui_deployment_dir}}/app/components"
+  args:
+    remotes: "{{web_ui_install_dir}}/app/components"
+    creates: "{{web_ui_deployment_dir}}/app/components"
+  # Errors when current does not exists (first deployment)
+  ignore_errors: yes
+
+- name: Install Bower dependencies
+  command: node_modules/.bin/bower install --config.interactive=false
+  args:
+    chdir: "{{ web_ui_deployment_dir }}"
+
+- name: Generate Web Interface
+  command: node_modules/.bin/gulp dist
+  args:
+    chdir: "{{ web_ui_deployment_dir }}"
+
+- name: Create symlink release -> current
+  file:
+    src: "{{ web_ui_deployment_dir }}"
+    dest: "{{ web_ui_install_dir }}"
+    state: link
+  when: irma_deployment_code_version != 'local'
+
+# vim: sw=2

--- a/roles/quarkslab.irma_provisioning_web_ui/tasks/main.yml
+++ b/roles/quarkslab.irma_provisioning_web_ui/tasks/main.yml
@@ -1,0 +1,18 @@
+---
+
+- name: Ensure that directory Frontend project directory is present
+  file:
+    path: "{{ web_ui_project_dir }}"
+    state: directory
+    owner: "{{ web_ui_user }}"
+    group: "{{ irma_server_group }}"
+    mode: 02750
+    recurse: "{{ vagrant_share|default(false) }}"
+
+- name: Ensure that www-data can access IRMA files and certificates
+  user:
+    name: www-data
+    groups: "{{ irma_server_group }},{{ irma_cert_group }}"
+    append: yes
+
+# vim: sw=2


### PR DESCRIPTION
a standalone repository for the web-ui.

The quarkslab/irma-frontend repository should only provide the API for
IRMA infrastructure. But, there is also the web interface. So, as there
is no need to get the web interface inside the repository anymore, we
decided to move it to another standalone repository.

Close: quarkslab/irma#20
