### PR TITLE
Change Stouts.mongodb version to 2.2.4

### DIFF
--- a/ansible-requirements.yml
+++ b/ansible-requirements.yml
@@ -28,8 +28,9 @@
   version: master
   name: mivok0.users
 
-- src: Stouts.mongodb
-  version: 2.1.11
+- src: https://github.com/Stouts/Stouts.mongodb.git
+  version: 2.2.4
+  name: Stouts.mongodb
 
 - src: https://github.com/willshersystems/ansible-sshd.git
   version: 0.4.2


### PR DESCRIPTION
The current version of Stouts.mongodb (2.1.11) fail during provisioning.

`TASK [Stouts.mongodb : Install MongoDB package] ********************************
fatal: [brain.irma]: FAILED! => {"changed": false, "failed": true, "msg": "No package matching 'mongodb-org' is available"}`

Problem fixed by using the last version (2.2.4).