### PR TITLE
Docker images support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,5 @@ group_vars/probe
 
 # Ignore python files (ansible plugins or scripts)
 *.pyc
+# Docker
+./Dockerfile

--- a/configure-docker-env.sh
+++ b/configure-docker-env.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Run this script with argument "probe" or "brain", then run "docker build".
+
+
+if [ "$1" = "probe" ]; then
+    echo "[+] Configuring docker environment for probe"
+    cp docker/probe/Dockerfile .
+elif [ "$1" = 'brain' ]; then
+    echo "[+] Configuring docker environment for brain"
+    cp docker/brain/Dockerfile .
+else
+    echo "Usage:" $0 "[probe|brain]"
+    exit 1
+fi
+
+if [ $? -ne 0 ]; then
+    exit 1
+fi
+
+echo "Done. You can now run docker build."
+
+exit 0

--- a/docker/brain/Dockerfile
+++ b/docker/brain/Dockerfile
@@ -1,0 +1,49 @@
+FROM debian:jessie
+
+# Environment
+ENV DEBIAN_FRONTEND noninteractive
+ENV ANSIBLE_FORCE_COLOR true
+ENV PYTHONPATH "/opt/irma/irma-probe/current/"
+ENV HOSTNAME irma
+ARG DOCKERBUILD=true
+
+# Update
+RUN apt-get update
+RUN apt-get install -y python-pip python-dev python-setuptools libffi-dev libssl-dev git wget locales lsb-release
+RUN pip install -U cffi ansible MarkupSafe cryptography
+
+# Fix locale
+RUN echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && locale-gen && update-locale
+
+# Copy install files
+RUN mkdir /tmp/install/
+ADD . /tmp/install/irma-ansible/
+WORKDIR /tmp/install/irma-ansible/
+ADD docker/brain/hosts/irma ./hosts/irma
+ADD docker/brain/create_rabbit_irma_users.sh /usr/bin/create_rabbit_irma_users.sh
+
+# Perform install
+ADD ansible-requirements.yml ansible-requirements.yml
+RUN ansible-galaxy install -r ansible-requirements.yml
+WORKDIR /tmp/install/
+RUN cd /tmp/install/irma-ansible && ansible-playbook -vvv -i /tmp/install/irma-ansible/hosts/irma /tmp/install/irma-ansible/playbooks/playbook.yml -c local
+
+# Post-install fixes
+RUN sed -i 's/brain.irma/127.0.0.1/' /opt/irma/irma-frontend/current/config/frontend.ini
+RUN sed -i 's/brain.irma/127.0.0.1/' /opt/irma/irma-brain/current/config/brain.ini
+## Deletes rabbitmq configuration - users will be re-created at startup.
+## rabbitmq stores configuration in mnesia tables, which depend on the hostname (can't be changed)
+## Can't change container hostname at build time (see https://github.com/docker/docker/issues/1916)
+## Other possible way: add a node_name in rabbit-related vhost group_vars
+RUN rm -rf /var/lib/rabbitmq/mnesia/
+
+# Ports
+EXPOSE 80
+EXPOSE 8081
+EXPOSE 21
+EXPOSE 5672
+
+# Init
+ADD ./docker/brain/supervisord.conf /supervisord.conf
+
+ENTRYPOINT ["/usr/local/bin/supervisord", "-c", "/supervisord.conf"]

--- a/docker/brain/create_rabbit_irma_users.sh
+++ b/docker/brain/create_rabbit_irma_users.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+# for some reason, without sleep this script gets stuck instead of failing if
+# rabbit is not already running...
+sleep 5
+
+function exit_error {
+    # prevent supervisord from restarting this script too quickly
+    sleep 1
+    # rabbitmq has not started yet, this script will get restarted by supervisord
+    exit 1
+}
+
+# create vhosts
+if ! (rabbitmqctl -n rabbit@irma list_vhosts|grep -q mqbrain)
+then
+    rabbitmqctl -n rabbit@irma add_vhost mqbrain || exit_error
+fi
+if ! (rabbitmqctl -n rabbit@irma list_vhosts|grep -q mqfrontend)
+then
+    rabbitmqctl -n rabbit@irma add_vhost mqfrontend || exit_error
+fi
+if ! (rabbitmqctl -n rabbit@irma list_vhosts|grep -q mqprobe)
+then
+    rabbitmqctl -n rabbit@irma add_vhost mqprobe || exit_error
+fi
+
+# create users
+if ! (rabbitmqctl -n rabbit@irma list_users|grep -q brain)
+then
+    rabbitmqctl -n rabbit@irma add_user brain brain || exit_error
+    rabbitmqctl set_permissions -p mqbrain brain '.*' '.*' '.*'
+fi
+if ! (rabbitmqctl -n rabbit@irma list_users|grep -q frontend)
+then
+    rabbitmqctl -n rabbit@irma add_user frontend frontend || exit_error
+    rabbitmqctl set_permissions -p mqfrontend frontend '.*' '.*' '.*'
+fi
+if ! (rabbitmqctl -n rabbit@irma list_users|grep -q probe)
+then
+    rabbitmqctl -n rabbit@irma add_user probe probe || exit_error
+    rabbitmqctl set_permissions -p mqprobe probe '.*' '.*' '.*'
+fi
+
+exit 0
+

--- a/docker/brain/hosts/example
+++ b/docker/brain/hosts/example
@@ -1,0 +1,5 @@
+# Put your host's IP in the corresponding section
+
+[frontend]
+[brain]
+[probe]

--- a/docker/brain/hosts/irma
+++ b/docker/brain/hosts/irma
@@ -1,0 +1,10 @@
+# Put your host's IP in the corresponding section
+
+[frontend]
+localhost
+[brain]
+localhost
+[probe]
+
+[docker]
+localhost

--- a/docker/brain/supervisord.conf
+++ b/docker/brain/supervisord.conf
@@ -1,0 +1,49 @@
+[supervisord]
+logfile_maxbytes = 50MB
+logfile_backups = 10
+loglevel = info
+childlogdir = /var/log/supervisor
+logfile = /var/log/supervisor/supervisord.log
+nodaemon=true
+
+[program:rabbitmq_server]
+command=/usr/sbin/rabbitmq-server
+autostart=true
+startsecs=0
+startretries=0
+autorestart=unexpected
+exitcodes=0
+priority=1
+
+[program:postgresql]
+command=service postgresql start
+autostart=true
+startsecs=0
+startretries=0
+autorestart=unexpected
+exitcodes=0
+priority=6
+
+[program:sshd]
+command=/usr/sbin/sshd -D
+priority=7
+
+[program:nginx]
+command=service nginx start
+autostart=true
+startsecs=0
+startretries=0
+autorestart=unexpected
+exitcodes=0
+priority=8
+
+[program:create_rabbit_users]
+command=/usr/bin/create_rabbit_irma_users.sh
+startsecs=0
+autorestart=unexpected
+startretries=10
+exitcodes=0
+priority=10
+
+[include]
+files = /etc/supervisor/conf.d/*

--- a/docker/probe/Dockerfile
+++ b/docker/probe/Dockerfile
@@ -1,0 +1,44 @@
+FROM debian:jessie
+
+# Environment
+ENV DEBIAN_FRONTEND noninteractive
+ENV ANSIBLE_FORCE_COLOR true
+ENV PYTHONPATH "/opt/irma/irma-probe/current/"
+ENV HOSTNAME irma
+ARG DOCKERBUILD=true
+
+# Update
+RUN apt-get update
+RUN apt-get install -y python-pip python-dev python-setuptools libffi-dev libssl-dev git wget locales lsb-release
+RUN pip install -U cffi ansible MarkupSafe cryptography
+
+# Fix locale
+RUN echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && locale-gen && update-locale
+
+# Copy install files
+RUN mkdir /tmp/install/
+ADD . /tmp/install/irma-ansible/
+WORKDIR /tmp/install/irma-ansible/
+ADD docker/probe/hosts/irma ./hosts/irma
+
+# Prepare install
+## required for virusblokada
+RUN mkdir -p /etc/terminfo/d && ln -s /lib/terminfo/d/dumb /etc/terminfo/d/dumb
+
+# Perform install
+ADD ansible-requirements.yml ansible-requirements.yml
+RUN ansible-galaxy install -r ansible-requirements.yml
+WORKDIR /tmp/install/
+RUN cd /tmp/install/irma-ansible && ansible-playbook -vvv -i /tmp/install/irma-ansible/hosts/irma /tmp/install/irma-ansible/playbooks/playbook.yml -c local
+
+# Post-install fixes
+## Connect the probe to the brain
+RUN sed -i 's/brain.irma/irma/' /opt/irma/irma-probe/current/config/probe.ini
+RUN sed -i "s/nodaemon = false/nodaemon = true/" /etc/supervisord.conf
+RUN chmod 755 /usr/local/uvscan/uvscan
+ENV TERM dumb
+
+# Init
+ADD ./docker/probe/supervisord.conf /supervisord.conf
+
+ENTRYPOINT ["/usr/local/bin/supervisord", "-c", "/supervisord.conf"]

--- a/docker/probe/hosts/example
+++ b/docker/probe/hosts/example
@@ -1,0 +1,5 @@
+# Put your host's IP in the corresponding section
+
+[frontend]
+[brain]
+[probe]

--- a/docker/probe/hosts/irma
+++ b/docker/probe/hosts/irma
@@ -1,0 +1,38 @@
+# Put your host's IP in the corresponding section
+
+[frontend]
+[brain]
+[probe]
+localhost
+
+[mcafee]
+localhost
+[clamav]
+localhost
+[comodo]
+localhost
+[avg]
+localhost
+[bitdefender]
+localhost
+[virusblokada]
+localhost
+
+[docker]
+localhost
+
+
+# need a key
+[drweb]
+#not an antivirus
+[static-analyzer]
+#not a antivirus
+[peid]
+#need a key
+[zoner]
+#need a valid url
+[escan]
+#need internet
+[virustotal]
+#need a key
+[avast]

--- a/docker/probe/supervisord.conf
+++ b/docker/probe/supervisord.conf
@@ -1,0 +1,37 @@
+[supervisord]
+logfile_maxbytes = 50MB
+logfile_backups = 10
+loglevel = info
+childlogdir = /var/log/supervisor
+logfile = /var/log/supervisor/supervisord.log
+nodaemon=true
+
+[program:avgdeamon]
+command=service avgd start
+autostart=true
+startsecs=0
+startretries=0
+autorestart=unexpected
+exitcodes=0
+priority=1
+
+# [program:drwebdeamon]
+# command=service drweb-configd restart
+# autostart=true
+# startsecs=0
+# startretries=0
+# autorestart=unexpected
+# exitcodes=0
+# priority=1
+
+[program:clamavdeamon]
+command=service clamav-daemon start
+autostart=true
+startsecs=0
+startretries=0
+autorestart=unexpected
+exitcodes=0
+priority=1
+
+[include]
+files = /etc/supervisor/conf.d/*

--- a/playbooks/group_vars/all.yml
+++ b/playbooks/group_vars/all.yml
@@ -79,3 +79,10 @@ sshd:
   PermitRootLogin: no
   Protocol: 2
   X11Forwarding: no
+
+
+## True if irma is being installed in docker.
+## In that case, do not start services at build time.
+## This variable is set to 'true' in Dockerfile using ARG
+## lookup('env', 'X') return '' if the environment variable is not defined.
+docker_build: "{{ lookup('env', 'DOCKERBUILD') == 'true' }}"

--- a/playbooks/group_vars/frontend-demo.yml
+++ b/playbooks/group_vars/frontend-demo.yml
@@ -102,6 +102,9 @@ apt_repositories_code_names:
   - '{{ ansible_distribution_release }}-backports'
 
 
+## PIP extras args
+pip_extra_args: "--default-timeout 120"
+
 ## uWSGI role
 uwsgi_install_method: "{{ 'pip' if (default_use_debian_repo | bool) == False else 'repo' }}"
 uwsgi_plugins:

--- a/playbooks/group_vars/frontend.yml
+++ b/playbooks/group_vars/frontend.yml
@@ -150,7 +150,7 @@ supervisor_programs_frontend:
     killasgroup: true
   - name: frontend_api
     command: >
-      uwsgi -s 127.0.0.1:8081 --disable-logging --master --workers 4 --need-app
+      uwsgi -s 0.0.0.0:8081 --disable-logging --master --workers 4 --need-app
       --plugins python --chdir {{ frontend_install_dir }} --home {{ frontend_install_dir }}/venv
       --python-path {{ frontend_install_dir }}/venv --mount /api=frontend/api/base.py --lazy
     user: "{{ irma_user }}"

--- a/playbooks/provisioning.yml
+++ b/playbooks/provisioning.yml
@@ -5,7 +5,7 @@
   sudo: yes
   roles:
     - { role: quarkslab.apt, tags: 'apt' }
-    - { role: franklinkim.ufw, tags: 'ufw' }
+    - { role: franklinkim.ufw, tags: 'ufw', when: "not docker_build"}
     - { role: quarkslab.irma_provisioning_common, tags: 'common' }
     - { role: mivok0.users, tags: 'users' }
     - { role: franklinkim.sudo, tags: 'sudo' }
@@ -22,7 +22,7 @@
     - { role: quarkslab.supervisor, tags: 'supervisor', supervisor_programs: "{{ supervisor_programs_frontend }}" }
     - { role: quarkslab.irma_provisioning_frontend, tags: 'frontend' }
     - { role: jdauphant.nginx, tags: 'nginx' }
-    - { role: quarkslab.ufw_additional, tags: 'ufw', ufw_additional_rules: "{{ frontend_ufw_additional_rules }}" }
+    - { role: quarkslab.ufw_additional, tags: 'ufw', ufw_additional_rules: "{{ frontend_ufw_additional_rules }}", when: "not docker_build" }
 
 
 - name: Brain provisioning
@@ -33,7 +33,7 @@
     - { role: Mayeu.RabbitMQ, tags: 'rabbitmq' }
    # - { role: quarkslab.pureftpd, tags: 'pureftpd' }
     - { role: quarkslab.irma_provisioning_brain, tags: 'brain' }
-    - { role: quarkslab.ufw_additional, tags: 'ufw', ufw_additional_rules: "{{ brain_ufw_additional_rules }}" }
+    - { role: quarkslab.ufw_additional, tags: 'ufw', ufw_additional_rules: "{{ brain_ufw_additional_rules }}", when: "not docker_build" }
 
 
 # NOTE: moved down sudo attributes as windows does not support sudo.

--- a/roles/quarkslab.avast/handlers/main.yml
+++ b/roles/quarkslab.avast/handlers/main.yml
@@ -4,4 +4,5 @@
   service:
     name: avast
     state: restarted
+  when: not docker_build
   sudo: yes

--- a/roles/quarkslab.avg/handlers/main.yml
+++ b/roles/quarkslab.avg/handlers/main.yml
@@ -5,3 +5,4 @@
     name: avgd
     state: restarted
   sudo: yes
+  when: not docker_build

--- a/roles/quarkslab.bitdefender/tasks/install.yml
+++ b/roles/quarkslab.bitdefender/tasks/install.yml
@@ -26,6 +26,10 @@
     replace: 'cat  LICENSE'
     backup: yes
 
+- name: BitDefender | Install psmisc (Docker)
+  apt: name=psmisc state=present
+  when: docker_build
+
 - name: BitDefender | Run installer, do not install GUI
   shell: (echo 'accept'; echo 'n') | sh /tmp/BitDefender-Antivirus-Scanner-linux.run
   sudo: yes

--- a/roles/quarkslab.clamav/handlers/main.yml
+++ b/roles/quarkslab.clamav/handlers/main.yml
@@ -2,3 +2,4 @@
 
 - name: ClamAV | restart daemon
   action: service name=clamav-daemon state=restarted
+  when: not docker_build

--- a/roles/quarkslab.drweb/handlers/main.yml
+++ b/roles/quarkslab.drweb/handlers/main.yml
@@ -4,4 +4,5 @@
   service:
     name: drweb-configd
     state: restarted
+  when: not docker_build
   sudo: yes

--- a/roles/quarkslab.irma_deployment_brain/tasks/main.yml
+++ b/roles/quarkslab.irma_deployment_brain/tasks/main.yml
@@ -50,3 +50,4 @@
     state: restarted
   sudo: yes
   with_items: "{{ supervisor_programs_brain }}"
+  when: not docker_build

--- a/roles/quarkslab.irma_deployment_frontend/tasks/main.yml
+++ b/roles/quarkslab.irma_deployment_frontend/tasks/main.yml
@@ -50,6 +50,13 @@
   command: node_modules/.bin/bower install --config.interactive=false
   args:
     chdir: "{{ frontend_deployment_dir }}/web"
+  when: not docker_build
+
+- name: Install Bower dependencies
+  command: node_modules/.bin/bower install --allow-root --config.interactive=false
+  args:
+    chdir: "{{ frontend_deployment_dir }}/web"
+  when: docker_build
 
 - name: Generate Web Frontend
   command: node_modules/.bin/gulp dist

--- a/roles/quarkslab.irma_deployment_frontend/tasks/main.yml
+++ b/roles/quarkslab.irma_deployment_frontend/tasks/main.yml
@@ -80,6 +80,7 @@
     name: "{{ item.name }}"
     state: restarted
   sudo: yes
+  when: not docker_build
   with_items: "{{ supervisor_programs_frontend }}"
 
 - name: Restart Init.d services
@@ -87,5 +88,6 @@
     name: "{{ item }}"
     state: restarted
   sudo: yes
+  when: not docker_build
   with_items:
     - nginx

--- a/roles/quarkslab.irma_deployment_probe/tasks/linux/probe_deployment.yml
+++ b/roles/quarkslab.irma_deployment_probe/tasks/linux/probe_deployment.yml
@@ -41,3 +41,4 @@
     state: restarted
   sudo: yes
   with_items: "{{ supervisor_programs_probe }}"
+  when: not docker_build

--- a/roles/quarkslab.irma_provisioning_brain/handlers/main.yml
+++ b/roles/quarkslab.irma_provisioning_brain/handlers/main.yml
@@ -2,9 +2,11 @@
 
 - name: Restart Pure-FTPD daemon
   service: name=pure-ftpd state=restarted
+  when: not docker_build
   sudo: yes
 
 - name: Reload UFW
   ufw:
     state: reloaded
+  when: not docker_build
   sudo: yes

--- a/roles/quarkslab.irma_provisioning_brain/tasks/sftpd.yml
+++ b/roles/quarkslab.irma_provisioning_brain/tasks/sftpd.yml
@@ -41,3 +41,4 @@
   service:
     name: sshd
     state: restarted
+  when: not docker_build

--- a/roles/quarkslab.irma_provisioning_common/tasks/main.yml
+++ b/roles/quarkslab.irma_provisioning_common/tasks/main.yml
@@ -7,7 +7,7 @@
     sysctl_set: yes
     state: present
     reload: yes
-  when: ansible_distribution in ['Debian', 'Ubuntu']
+  when: ansible_distribution in ['Debian', 'Ubuntu'] and not docker_build
 
 - include: debian_install_packages.yml
   when: ansible_distribution == 'Debian'

--- a/roles/quarkslab.irma_provisioning_common/tasks/main.yml
+++ b/roles/quarkslab.irma_provisioning_common/tasks/main.yml
@@ -13,6 +13,8 @@
   when: ansible_distribution == 'Debian'
 
 - include: hosts.yml
+  when: not docker_build
+
 - include: users_groups.yml
 
 - include: locales.yml

--- a/roles/quarkslab.irma_provisioning_probe/tasks/main.yml
+++ b/roles/quarkslab.irma_provisioning_probe/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 
 - include: linux/provisioning_probe.yml
-  when: "ansible_distribution in ['Debian', 'Ubuntu']"
+  when: "ansible_distribution in ['Debian', 'Ubuntu'] and not docker_build"
   sudo: yes
 
 - include: windows/provisioning_probe.yml

--- a/roles/quarkslab.mcafee_vscl/tasks/install.yml
+++ b/roles/quarkslab.mcafee_vscl/tasks/install.yml
@@ -11,3 +11,7 @@
   shell: tar xzf "{{ mcafee_temp_dir }}/vscl.tar.gz" -C /usr/local/uvscan
 
 - file: path=/usr/local/uvscan/uvscan mode="655"
+  when: "not docker_build"
+
+- file: path=/usr/local/uvscan/uvscan mode="755"
+  when: "docker_build"

--- a/roles/quarkslab.pureftpd/tasks/main.yml
+++ b/roles/quarkslab.pureftpd/tasks/main.yml
@@ -34,3 +34,4 @@
 
 - name: Daemon | Ensure Pure-FTPD is started
   service: name=pure-ftpd state=started
+  when: not docker_build

--- a/roles/quarkslab.supervisor/handlers/main.yml
+++ b/roles/quarkslab.supervisor/handlers/main.yml
@@ -4,3 +4,4 @@
   service:
     name: supervisord
     state: restarted
+  when: not docker_build

--- a/roles/quarkslab.virusblokada/tasks/main.yml
+++ b/roles/quarkslab.virusblokada/tasks/main.yml
@@ -15,13 +15,15 @@
     - libstdc++6
 
 - name: VBA32 | Check version
-  command: /opt/vba/vbacl --version
+  command: /opt/vba/vbacl/vbacl --version
   ignore_errors: yes
   register: virusblokada_present
 
 - include: install.yml
   when: virusblokada_present | failed
 
+# vbaupd segfaults if IPv6 addresses are present in /etc/hosts
+# when docker is used, cannot copy or move file to /etc/hosts, but shell redirections work
 - name: VBA32 | Update definition files
-  shell: vbacl --update
+  shell: cp /etc/hosts /etc/hosts.bak; grep -v ':' /etc/hosts.bak > /etc/hosts; vbacl --update; cat /etc/hosts.bak > /etc/hosts; rm /etc/hosts.bak
   sudo: yes

--- a/roles/quarkslab.zoner/handlers/main.yml
+++ b/roles/quarkslab.zoner/handlers/main.yml
@@ -4,4 +4,5 @@
   service:
     name: zavd
     state: restarted
+  when: not docker_build
   sudo: yes


### PR DESCRIPTION
Hi,
This pull request adds support for building docker images of irma, based on @p-col's work in pull request #110, including new fixes, simplifications, and a rebase/history rewrite to make the changes more understandable.
It adds a new ansible variables, docker_build, to indicate whether the install is being performed as part of a docker build.
This variable is then used to perform required tweaks (do not start services, do not use ufw...).

To build a docker image, use the "configure-docker-env.sh" script at the root, then run "docker build".